### PR TITLE
Fix channel bug in bankfiles.py

### DIFF
--- a/fluidpatcher/bankfiles.py
+++ b/fluidpatcher/bankfiles.py
@@ -168,7 +168,7 @@ class RouterRule(BankObject):
 
     def add(self, addfunc):
         for type in self.type:
-            for chan in self.chan:
+            for chan in self.chan or [None]:
                 addfunc(type, chan, **self.pars)
 
     @staticmethod


### PR DESCRIPTION
add method on router rules wouldn't add rule if chan parameter was empty