### PR TITLE
Fix direct patch selection

### DIFF
--- a/fluidpatcher.pyw
+++ b/fluidpatcher.pyw
@@ -256,10 +256,10 @@ class MainWindow(wx.Frame):
     def listener(self, sig):
         if hasattr(sig, 'val'):
             if hasattr(sig, 'patch') and fp.patches:
-                if sig.patch < 0:
+                if sig.patch == -1:
                     self.select_patch(pno=(self.pno + sig.val) % len(fp.patches))
                 else:
-                    self.select_patch(pno=self.patch)
+                    self.select_patch(pno=sig.patch)
             elif hasattr(sig, 'lcdwrite'):
                 if hasattr(sig, 'format'):
                     val = format(sig.val, sig.format)

--- a/fluidpatcher/__init__.py
+++ b/fluidpatcher/__init__.py
@@ -16,7 +16,7 @@ Requires:
 - libfluidsynth
 """
 
-__version__ = '0.8.3'
+__version__ = '0.8.4'
 
 from pathlib import Path
 from copy import deepcopy
@@ -451,10 +451,12 @@ class FluidPatcher:
             if sig.patch in self.patches:
                 sig.patch = self.patches.index(sig.patch)
             elif sig.patch == 'select':
-                sig.patch = int(sig.val) % len(self.patches)
-            elif sig.patch[-1] in '+-':
+                sig.patch = int(sig.val - 1) % len(self.patches)
+            elif str(sig.patch)[-1] in '+-':
                 sig.val = int(sig.patch[-1] + sig.patch[:-1])
                 sig.patch = -1
+            elif isinstance(sig.patch, int):
+                sig.patch -= 1
             else:
                 sig.patch = -1
                 sig.val = 0

--- a/headlesspi.py
+++ b/headlesspi.py
@@ -40,7 +40,7 @@ def connect_controls():
     fp.add_router_rule(type=TYPE, chan=CHAN, par1=INC_PATCH, par2='1-127', patch='1+')
     fp.add_router_rule(type=TYPE, chan=CHAN, par1=BANK_INC, par2='1-127', bank=1)
     if SELECT_PATCH != None:
-        selectspec =  f"0-127=0-{min(len(fp.patches) - 1, 127)}" # transform CC values into patch numbers
+        selectspec =  f"0-127=1-{min(len(fp.patches), 128)}" # transform CC values into patch numbers
         fp.add_router_rule(type='cc', chan=CHAN, par1=SELECT_PATCH, par2=selectspec, patch='select')
     if SHUTDOWN_BTN != None:
         fp.add_router_rule(type=TYPE, chan=CHAN, par1=SHUTDOWN_BTN, shutdown=1)
@@ -152,7 +152,7 @@ class HeadlessSynth:
     def listener(self, sig):
     # catches custom midi :sig to change patch/bank
         if hasattr(sig, 'patch'):
-            if sig.patch < 0:
+            if sig.patch == -1:
                 self.select_patch((self.pno + sig.val) % len(fp.patches))
             else:
                 self.select_patch(sig.patch)

--- a/squishbox.py
+++ b/squishbox.py
@@ -19,7 +19,7 @@ display, standard menu and input functions, and a few utilities such as
 shell command access and wifi control.
 """
 
-__version__ = '0.8.3'
+__version__ = '0.8.4'
 
 import re
 import subprocess
@@ -736,7 +736,7 @@ class FluidBox:
         routing, and additional parameters corresponding to the rule
         parameters. The following custom rules are handled:
 
-        - `patch`: a patch index to be selected. If `patch` has a '+' or '-'
+        - `patch`: a patch name or index to be selected. If `patch` has a '+' or '-'
             suffix, increment the current patch index instead.
         - `lcdwrite`: a string to be written to the LCD, right-justified. If `format`
             is provided, the formatted `val` parameter is appended
@@ -745,7 +745,7 @@ class FluidBox:
         """
         if 'val' in sig:
             if 'patch' in sig:
-                if sig.patch < 0:
+                if sig.patch == -1:
                     self.pno = (self.pno + sig.val) % len(fp.patches)
                 else:
                     self.pno = sig.patch
@@ -764,6 +764,7 @@ class FluidBox:
 
     def patchmode(self):
         """Selects a patch and displays the main screen"""
+        sb.lcd_clear()
         if fp.patches:
             warn = fp.apply_patch(self.pno)
         else:
@@ -961,6 +962,7 @@ class FluidBox:
             sb.lcd_write("Shutting down..", 0, mode='ljust')
             sb.lcd_write("Wait 30s, unplug", 1, mode='ljust', now=True)
             sb.shell_cmd("sudo poweroff")
+            sys.exit()
         elif k == 1:
             self.midi_devices()
         elif k == 2:


### PR DESCRIPTION
- bug when parsing patch rule if it is an int, cast to string
- patch numbers start from 1, not zero