### PR TITLE
Interrupt event processing when changing patch

### DIFF
--- a/fluidpatcher/__init__.py
+++ b/fluidpatcher/__init__.py
@@ -460,8 +460,9 @@ class FluidPatcher:
             else:
                 sig.patch = -1
                 sig.val = 0
-            return True
         if self.midi_callback: self.midi_callback(sig)
+        if 'patch' in sig:
+            return True
 
     def _refresh_bankfonts(self):
         sfneeded = set()

--- a/fluidpatcher/__init__.py
+++ b/fluidpatcher/__init__.py
@@ -460,6 +460,7 @@ class FluidPatcher:
             else:
                 sig.patch = -1
                 sig.val = 0
+            return True
         if self.midi_callback: self.midi_callback(sig)
 
     def _refresh_bankfonts(self):

--- a/fluidpatcher/pfluidsynth.py
+++ b/fluidpatcher/pfluidsynth.py
@@ -626,9 +626,9 @@ class Synth:
             elif LADSPA_SUPPORT and 'ladspafx' in rule:
                 if res.ladspafx in self.ladspafx:
                     self.ladspafx[res.ladspafx].setcontrol(res.port, res.val)
-            else:
-                # not handled here, pass it to the callback
-                if self.midi_callback: self.midi_callback(res)
+            elif self.midi_callback:
+                # not handled here, pass result to the callback
+                if self.midi_callback(res): return
         if dt > 0: self.clocks = t, self.clocks[0]
         if self.midi_callback:
             # send the original event to the callback


### PR DESCRIPTION
The midisignal_callback can change the current set of router rules (e.g. patch rules). This provides a way for the callback to tell the custom router to stop processing the current event in this case. Fixes #101